### PR TITLE
Upgrade Apache Commons Collections to v3.2.2/4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,9 @@
         <!-- Dependency Version Numbers -->
         <spring.version>4.0.3.RELEASE</spring.version>
         <commons.lang.version>3.2</commons.lang.version>
-        <commons.collections.version>4.0</commons.collections.version>
+        <commons.collections.version>4.1</commons.collections.version>
         <commons.codec.version>1.9</commons.codec.version>
+		<commons.collections3.version>3.2.2</commons.collections3.version>
         <commons.beanutils.version>1.9.2</commons.beanutils.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.httpclient.version>4.3.3</commons.httpclient.version>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -34,6 +34,17 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>${commons.beanutils.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>${commons.collections3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/