### PR TITLE
Changed the PropertySource to use getString instead of getProperty

### DIFF
--- a/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
+++ b/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
@@ -38,7 +38,7 @@ public class ApacheCommonsConfiguration2PropertySource extends EnumerablePropert
 
     @Override
     public Object getProperty(String name) {
-        return source.getProperty(name);
+        return source.getString(name);
     }
 
 }


### PR DESCRIPTION
Changed the PropertySource to use getString instead of getProperty for ${placeholder} replacement.