### PR TITLE
Fixed issue with ApacheCommonsConfiguration2PropertySource.getProperty

### DIFF
--- a/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
+++ b/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
@@ -20,7 +20,6 @@ import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.configuration2.Configuration;
 import org.springframework.core.env.EnumerablePropertySource;
 
-import java.util.Collection;
 import java.util.List;
 
 /**

--- a/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
+++ b/utilities/src/main/java/org/craftercms/commons/spring/ApacheCommonsConfiguration2PropertySource.java
@@ -20,6 +20,9 @@ import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.configuration2.Configuration;
 import org.springframework.core.env.EnumerablePropertySource;
 
+import java.util.Collection;
+import java.util.List;
+
 /**
  * Implementation of {@link EnumerablePropertySource} where a source is an Apache Commons Configuration 2 {@link Configuration}.
  *
@@ -38,7 +41,15 @@ public class ApacheCommonsConfiguration2PropertySource extends EnumerablePropert
 
     @Override
     public Object getProperty(String name) {
-        return source.getString(name);
+        Object value = source.getProperty(name);
+        // Call the appropriate getters to resolve ${placeholder}s
+        if (value instanceof String) {
+            return source.getString(name);
+        } else if (value instanceof List) {
+            return source.getList(name);
+        } else {
+            return value;
+        }
     }
 
 }


### PR DESCRIPTION
* Now getProperty won't force `getString` on all properties and it will execute variable interpolation appropriately.
