### PR TITLE
Add get/set endpoint option for S3

### DIFF
--- a/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3Profile.java
+++ b/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3Profile.java
@@ -27,6 +27,10 @@ public class S3Profile extends AbstractAwsProfile {
      * Name of the bucket.
      */
     protected String bucketName;
+    /**
+     * Endpoint to allow for connection to S3 compatible cloud storage service (ex: Openstack Swift)
+     */
+    protected String endpoint;
 
     public String getBucketName() {
         return bucketName;
@@ -34,6 +38,14 @@ public class S3Profile extends AbstractAwsProfile {
 
     public void setBucketName(final String bucketName) {
         this.bucketName = bucketName;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public void setEndpoint(final String endpoint) {
+        this.endpoint = endpoint;
     }
 
 }

--- a/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3ProfileMapper.java
+++ b/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3ProfileMapper.java
@@ -31,12 +31,20 @@ import static org.craftercms.commons.config.ConfigUtils.getRequiredStringPropert
 public class S3ProfileMapper extends AbstractAwsProfileMapper<S3Profile> {
 
     private static final String CONFIG_KEY_BUCKET = "bucketName";
+    private static final String CONFIG_KEY_ENDPOINT = "endpoint";
 
     @Override
     protected S3Profile mapProfile(HierarchicalConfiguration<ImmutableNode> profileConfig)
             throws ConfigurationException {
         S3Profile profile = super.mapProfile(profileConfig);
         profile.setBucketName(getRequiredStringProperty(profileConfig, CONFIG_KEY_BUCKET));
+
+        /**
+         * Check if <endpoint> is provided as it is optional
+         */
+        if(profileConfig.getString(CONFIG_KEY_ENDPOINT) != null && !profileConfig.getString(CONFIG_KEY_ENDPOINT).isEmpty()){
+            profile.setEndpoint(getRequiredStringProperty(profileConfig, CONFIG_KEY_ENDPOINT));
+        }
 
         return profile;
     }

--- a/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3ProfileMapper.java
+++ b/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/S3ProfileMapper.java
@@ -21,6 +21,7 @@ import org.apache.commons.configuration2.tree.ImmutableNode;
 import org.craftercms.commons.config.ConfigurationException;
 
 import static org.craftercms.commons.config.ConfigUtils.getRequiredStringProperty;
+import static org.craftercms.commons.config.ConfigUtils.getStringProperty;
 
 /**
  * Configuration mapper for {@link S3Profile}s.
@@ -40,11 +41,9 @@ public class S3ProfileMapper extends AbstractAwsProfileMapper<S3Profile> {
         profile.setBucketName(getRequiredStringProperty(profileConfig, CONFIG_KEY_BUCKET));
 
         /**
-         * Check if <endpoint> is provided as it is optional
+         * Optional: <endpoint> is provided
          */
-        if(profileConfig.getString(CONFIG_KEY_ENDPOINT) != null && !profileConfig.getString(CONFIG_KEY_ENDPOINT).isEmpty()){
-            profile.setEndpoint(getRequiredStringProperty(profileConfig, CONFIG_KEY_ENDPOINT));
-        }
+        profile.setEndpoint(getStringProperty(profileConfig, CONFIG_KEY_ENDPOINT));
 
         return profile;
     }


### PR DESCRIPTION
Goal: Allow user to add an optional <endpoint> field in their AWS S3 profile configuration so that one can upload files to a S3 compatible cloud storage service (ex: Openstack Swift)

S3ProfileMapper.java: Check for <endpoint> field in AWS S3 profile configuration. If exist, set endpoint to profile
S3Profile.java: Add getter and setter for endpoint