### PR TITLE
Use a non-singleton CredentialsProvider to prevent credentials from expiring

### DIFF
--- a/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/AbstractAwsProfile.java
+++ b/utilities/src/main/java/org/craftercms/commons/config/profiles/aws/AbstractAwsProfile.java
@@ -86,9 +86,8 @@ public abstract class AbstractAwsProfile extends ConfigurationProfile {
     public AwsCredentialsProvider getCredentialsProvider() {
         if (StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
             return StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey));
-        } else {
-            return DefaultCredentialsProvider.create();
         }
+        return DefaultCredentialsProvider.builder().build();
     }
 
     @Override


### PR DESCRIPTION
Use a non-singleton CredentialsProvider to prevent credentials from expiring
https://github.com/craftercms/craftercms/issues/7375