### PR TITLE
Fix write path regex to accept a leading dot in folder name

### DIFF
--- a/validation/src/main/resources/esapi/ESAPI.properties
+++ b/validation/src/main/resources/esapi/ESAPI.properties
@@ -483,7 +483,7 @@ Validator.USERNAME=^[a-zA-Z][\\w.\\-@+]+$
 Validator.GROUP_NAME=^[a-zA-Z][\\w.\\-]*$
 Validator.ALPHANUMERIC=^[a-zA-Z0-9]*$
 Validator.SEARCH_KEYWORDS=^[\\w\\s\\-\\"\\'\\.!@#$%&\\*\\/\\(\\)\\p{IsLatin}]*$
-Validator.CONTENT_PATH_WRITE=^(([\\w\\-/]|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?)+))(([\\w\\-\\s]+\\.?/?)|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?))*(((crafter\\-level\\-descriptor\\.level)|([\\w\\-\\s]))+\\.[\\w]+)?$
+Validator.CONTENT_PATH_WRITE=^(([\\w\\-/]\\.?|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?)+))(([\\w\\-\\s]+\\.?/?)|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?))*(((crafter\\-level\\-descriptor\\.level)|([\\w\\-\\s]))+\\.[\\w]+)?$
 # CONTENT_PATH_READ is based on Validator.FileName pattern below
 Validator.CONTENT_PATH_READ=^/?([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`]+([\\s\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])(/{0,2})([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])+(/{0,2}))*$
 Validator.CONFIGURATION_PATH=^([\\w\\-/ ]+([.]*[\\w\\-])+)*(\\.[\w]+)?/?$

--- a/validation/src/test/java/org/craftercms/commons/validation/validators/impl/ContentNewPathValidatorTest.java
+++ b/validation/src/test/java/org/craftercms/commons/validation/validators/impl/ContentNewPathValidatorTest.java
@@ -106,6 +106,7 @@ public class ContentNewPathValidatorTest implements ValidatorTest {
         assertRejected("../../site/website");
         assertRejected("./site/website");
         assertRejected("/site/website/../../sample");
+        assertRejected("/./website/sample");
     }
 
     @Test
@@ -134,6 +135,13 @@ public class ContentNewPathValidatorTest implements ValidatorTest {
         assertRejected("{{version}}");
         assertRejected("{version/sample/path}");
         assertRejected("/sample/path/{with{wrong{curl{brances}}}");
+    }
+
+    @Test
+    public void testSiteScreenshots() {
+        assertValid("/.crafter/screenshots");
+        assertValid("/.crafter/screenshots/default.png");
+        assertRejected("/..crafter/screenshots/default.png");
     }
 
     @Override


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/7405
Fix write path regex to accept a leading dot in folder name