### PR TITLE
Allow square brackets ([]) in search

### DIFF
--- a/validation/src/main/resources/esapi/ESAPI.properties
+++ b/validation/src/main/resources/esapi/ESAPI.properties
@@ -441,7 +441,7 @@ Validator.EMAIL=(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`
 Validator.USERNAME=^[a-zA-Z][\\w.\\-@+]+$
 Validator.GROUP_NAME=^[a-zA-Z][\\w.\\-]*$
 Validator.ALPHANUMERIC=^[a-zA-Z0-9]*$
-Validator.SEARCH_KEYWORDS=^[\\w\\s\\-\\"\\'\\.!@#$%&\\*\\/\\(\\)\\p{IsLatin}]*$
+Validator.SEARCH_KEYWORDS=^[\\w\\s\\-\\"\\'\\.!@#$%&\\*\\/\\(\\)\\[\\]\\p{IsLatin}]*$
 Validator.CONTENT_PATH_WRITE=^(([\\w\\-/]\\.?|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?)+))(([\\w\\-\\s]+\\.?/?)|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?))*(((crafter\\-level\\-descriptor\\.level)|([\\w\\-\\s]))+\\.[\\w]+)?$
 # CONTENT_PATH_READ is based on Validator.FileName pattern below
 Validator.CONTENT_PATH_READ=^/?([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`]+([\\s\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])?(/{0,2})([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])+(/{0,2}))*$

--- a/validation/src/test/java/org/craftercms/commons/validation/validators/impl/SearchKeywordsTest.java
+++ b/validation/src/test/java/org/craftercms/commons/validation/validators/impl/SearchKeywordsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2023 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2025 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -48,6 +48,11 @@ public class SearchKeywordsTest implements ValidatorTest {
 	@Test
 	public void testSpaces() {
 		assertValid("also this is valid");
+	}
+
+	@Test
+	public void testSquareBrackets() {
+		assertValid("[valid]");
 	}
 
 	@Override


### PR DESCRIPTION
https://github.com/craftercms/craftercms/issues/8351
Allow square brackets ([]) in search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation support for configuration path inputs to ensure only valid paths are accepted.
* **Bug Fixes**
  * Search keywords input now accepts square brackets [] without being flagged as invalid.
* **Tests**
  * Added test coverage to confirm search keywords correctly handle square brackets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->