### PR TITLE
Allow colon ':' in search params

### DIFF
--- a/validation/src/main/resources/esapi/ESAPI.properties
+++ b/validation/src/main/resources/esapi/ESAPI.properties
@@ -441,7 +441,7 @@ Validator.EMAIL=(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-zA-Z0-9!#$%&'*+/=?^_`
 Validator.USERNAME=^[a-zA-Z][\\w.\\-@+]+$
 Validator.GROUP_NAME=^[a-zA-Z][\\w.\\-]*$
 Validator.ALPHANUMERIC=^[a-zA-Z0-9]*$
-Validator.SEARCH_KEYWORDS=^[\\w\\s\\-\\"\\'\\.!@#$%&\\*\\/\\(\\)\\[\\]\\p{IsLatin}]*$
+Validator.SEARCH_KEYWORDS=^[\\w\\s\\-\\"\\'\\.!@#$%&\\:\\*\\/\\(\\)\\[\\]\\p{IsLatin}]*$
 Validator.CONTENT_PATH_WRITE=^(([\\w\\-/]\\.?|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?)+))(([\\w\\-\\s]+\\.?/?)|(\\{[\\w\\-\\s]+(\\.?[\\w\\-\\s])*\\}/?))*(((crafter\\-level\\-descriptor\\.level)|([\\w\\-\\s]))+\\.[\\w]+)?$
 # CONTENT_PATH_READ is based on Validator.FileName pattern below
 Validator.CONTENT_PATH_READ=^/?([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`]+([\\s\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])?(/{0,2})([\\w\\p{IsLatin}@$%^&{}\\[\\]()+\\-=,.:~'`])+(/{0,2}))*$


### PR DESCRIPTION
Allow colon ':' in search params
https://github.com/craftercms/craftercms/issues/8432

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated search keyword validation to allow colon (`:`) characters, enabling broader search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->