### PR TITLE
Make AuthenticationType an enum

### DIFF
--- a/git/src/main/java/org/craftercms/commons/git/utils/AuthConfiguratorFactory.java
+++ b/git/src/main/java/org/craftercms/commons/git/utils/AuthConfiguratorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -47,7 +47,7 @@ public class AuthConfiguratorFactory {
 	 * @param type the auth type
 	 * @return the builder
 	 */
-	public TypeBasedAuthConfiguratorBuilder forType(String type) {
+	public TypeBasedAuthConfiguratorBuilder forType(AuthenticationType type) {
 		return new TypeBasedAuthConfiguratorBuilder(sshConfig, type);
 	}
 

--- a/git/src/main/java/org/craftercms/commons/git/utils/AuthenticationType.java
+++ b/git/src/main/java/org/craftercms/commons/git/utils/AuthenticationType.java
@@ -22,18 +22,8 @@ package org.craftercms.commons.git.utils;
  * @since 4.0.0
  */
 public enum AuthenticationType {
-	NONE("none"),
-	BASIC("basic"),
-	TOKEN("token"),
-	PRIVATE_KEY("key");
-
-	private final String value;
-
-	AuthenticationType(String value) {
-		this.value = value;
-	}
-
-	public String getValue() {
-		return value;
-	}
+	none,
+	basic,
+	token,
+	private_key
 }

--- a/git/src/main/java/org/craftercms/commons/git/utils/AuthenticationType.java
+++ b/git/src/main/java/org/craftercms/commons/git/utils/AuthenticationType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -16,19 +16,24 @@
 package org.craftercms.commons.git.utils;
 
 /**
- * Constants for git authentication types
+ * Git authentication types
  *
  * @author joseross
  * @since 4.0.0
  */
-public interface AuthenticationType {
+public enum AuthenticationType {
+	NONE("none"),
+	BASIC("basic"),
+	TOKEN("token"),
+	PRIVATE_KEY("key");
 
-	String NONE = "none";
+	private final String value;
 
-	String BASIC = "basic";
+	AuthenticationType(String value) {
+		this.value = value;
+	}
 
-	String TOKEN = "token";
-
-	String PRIVATE_KEY = "key";
-
+	public String getValue() {
+		return value;
+	}
 }

--- a/git/src/main/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilder.java
+++ b/git/src/main/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilder.java
@@ -47,22 +47,22 @@ public class TypeBasedAuthConfiguratorBuilder extends AbstractAuthConfiguratorBu
 	@Override
 	public GitAuthenticationConfigurator build() {
 		switch (authType) {
-			case AuthenticationType.NONE:
+			case AuthenticationType.none:
 				logger.debug("No authentication will be used");
 				return new NoopAuthConfigurator();
-			case AuthenticationType.BASIC:
+			case AuthenticationType.basic:
 				if (isEmpty(username) && isEmpty(password)) {
 					throw new IllegalStateException("basic auth requires a username or password");
 				}
 				logger.debug("Username/password authentication will be used");
 				return new BasicUsernamePasswordAuthConfigurator(username, password);
-			case AuthenticationType.TOKEN:
+			case AuthenticationType.token:
 				if (isEmpty(username)) {
 					throw new IllegalStateException("token auth requires a username");
 				}
 				logger.debug("Token authentication will be used");
 				return new BasicUsernamePasswordAuthConfigurator(username, StringUtils.EMPTY);
-			case AuthenticationType.PRIVATE_KEY:
+			case AuthenticationType.private_key:
 				logger.debug("SSH private key authentication will be used");
 				return new SshPrivateKeyAuthConfigurator(sshConfig, privateKeyPath, privateKeyPassphrase);
 			default:

--- a/git/src/main/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilder.java
+++ b/git/src/main/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -37,9 +37,9 @@ public class TypeBasedAuthConfiguratorBuilder extends AbstractAuthConfiguratorBu
 	/**
 	 * The authentication type to use
 	 */
-	protected String authType;
+	protected AuthenticationType authType;
 
-	public TypeBasedAuthConfiguratorBuilder(File sshConfig, String authType) {
+	public TypeBasedAuthConfiguratorBuilder(File sshConfig, AuthenticationType authType) {
 		super(sshConfig);
 		this.authType = authType;
 	}

--- a/git/src/test/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilderTest.java
+++ b/git/src/test/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Crafter Software Corporation. All Rights Reserved.
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as published by
@@ -27,7 +27,7 @@ import java.io.File;
  */
 public class TypeBasedAuthConfiguratorBuilderTest extends AbstractAuthConfiguratorBuilderTest {
 
-	protected TypeBasedAuthConfiguratorBuilder createBuilder(String type) {
+	protected TypeBasedAuthConfiguratorBuilder createBuilder(AuthenticationType type) {
 		// The config path is not important for this test
 		return new TypeBasedAuthConfiguratorBuilder(new File("."), type);
 	}

--- a/git/src/test/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilderTest.java
+++ b/git/src/test/java/org/craftercms/commons/git/utils/TypeBasedAuthConfiguratorBuilderTest.java
@@ -34,31 +34,31 @@ public class TypeBasedAuthConfiguratorBuilderTest extends AbstractAuthConfigurat
 
 	@Test
 	public void testNoAuth() {
-		verify(createBuilder(AuthenticationType.NONE), NoopAuthConfigurator.class);
+		verify(createBuilder(AuthenticationType.none), NoopAuthConfigurator.class);
 	}
 
 	@Test
 	public void testBasicAuth() {
-		verify(createBuilder(AuthenticationType.BASIC)
+		verify(createBuilder(AuthenticationType.basic)
 			.withUsername("joe")
 			.withPassword("secret"), BasicUsernamePasswordAuthConfigurator.class);
 	}
 
 	@Test
 	public void testTokenAuth() {
-		verify(createBuilder(AuthenticationType.TOKEN)
+		verify(createBuilder(AuthenticationType.token)
 			.withUsername("token"), BasicUsernamePasswordAuthConfigurator.class);
 	}
 
 	@Test
 	public void testPrivateKeyAuth() {
-		verify(createBuilder(AuthenticationType.PRIVATE_KEY)
+		verify(createBuilder(AuthenticationType.private_key)
 			.withPrivateKeyPath("/some/key"), SshPrivateKeyAuthConfigurator.class);
 	}
 
 	@Test
 	public void testPrivateKeyAuthWithPass() {
-		verify(createBuilder(AuthenticationType.PRIVATE_KEY)
+		verify(createBuilder(AuthenticationType.private_key)
 			.withPrivateKeyPath("/some/key")
 			.withPrivateKeyPassphrase("secret"), SshPrivateKeyAuthConfigurator.class);
 	}

--- a/utilities/src/main/java/org/craftercms/commons/jackson/CaseInsensitiveEnumDeserializer.java
+++ b/utilities/src/main/java/org/craftercms/commons/jackson/CaseInsensitiveEnumDeserializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2007-2026 Crafter Software Corporation. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published by
+ * the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.craftercms.commons.jackson;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.deser.ContextualDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
+import java.io.IOException;
+
+import static java.lang.String.format;
+
+/**
+ * Custom Jackson deserializer for enums that allows case-insensitive deserialization.
+ * This is useful for cases where the JSON input may not match the exact case of the enum constants.
+ */
+public class CaseInsensitiveEnumDeserializer extends JsonDeserializer implements ContextualDeserializer {
+	private JavaType fieldType;
+
+	public CaseInsensitiveEnumDeserializer() {
+	}
+
+	private CaseInsensitiveEnumDeserializer(JavaType fieldType) {
+		this.fieldType = fieldType;
+	}
+
+	@Override
+	public JsonDeserializer<?> createContextual(DeserializationContext ctxt, BeanProperty property)
+			throws JsonMappingException {
+		// 'property' can be null if the deserializer is for a root-level value, not a bean property.
+		if (property != null) {
+			// Get the declared type of the field
+			JavaType type = property.getType();
+			return new CaseInsensitiveEnumDeserializer(type);
+		}
+		return this;
+	}
+
+	@Override
+	public Enum<?> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JacksonException {
+		String value = p.getText();
+		Class<Enum<?>> enumClass = (Class<Enum<?>>) fieldType.getRawClass();
+		for (Enum<?> enumConstant : enumClass.getEnumConstants()) {
+			if (enumConstant.name().equalsIgnoreCase(value)) {
+				return enumConstant;
+			}
+		}
+		throw new InvalidFormatException(p, format("Unable to deserialize value '%s' to enum %s", value,
+				fieldType.getRawClass().getName()), value, enumClass);
+	}
+}


### PR DESCRIPTION
Make AuthenticationType an enum
https://github.com/craftercms/craftercms/issues/6061

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication configuration now uses stronger typed values, reducing misconfiguration risk and improving validation.

* **New Features**
  * JSON parsing accepts enum-like values case-insensitively, making integrations more tolerant of input casing.

* **Tests**
  * Unit tests updated to align with the new authentication typing and parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->